### PR TITLE
Do substitution correctly even if characters that don't have to be encoded are.

### DIFF
--- a/pkg/mock/mock_test.go
+++ b/pkg/mock/mock_test.go
@@ -84,6 +84,17 @@ func TestMockServerMockHandler(t *testing.T) {
 			},
 			want: "url/encoded\n",
 		},
+		{
+			name: "url encoded alternative characters",
+			url:  "example.com/url%2Fencoded%2Dvalue",
+			options: []Option{
+				WithMockRoot("testdata/"),
+				WithDefaultVariables(
+					&VariableSubstitution{key: "name", value: "url/encoded-value"},
+				),
+			},
+			want: "url/encoded-value\n",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/mock/parse.go
+++ b/pkg/mock/parse.go
@@ -16,8 +16,9 @@ func (ms *MockServer) replacePathVars(u *url.URL) string {
 	for _, t := range ms.transformers {
 		switch tr := t.(type) {
 		case *VariableSubstitution:
-			search := url.PathEscape(tr.value)
+			search := tr.value
 			for idx, p := range parts {
+				p, _ = url.PathUnescape(p)
 				if p == search {
 					parts[idx] = fmt.Sprintf(":%s", strings.ToLower(tr.key))
 				}


### PR DESCRIPTION
Instead of trying to encode both sides before compare, decode both sides before compare.