### PR TITLE
Remove custom ports from Host in filepath.

### DIFF
--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -238,12 +238,14 @@ func (ms *MockServer) mockHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ms.logger.Info("parsing URL", "route", route, "url", r.URL)
 	path, localTransformers, err := route.ParseURL(r.URL)
 	if err != nil {
 		ms.logger.Error("failed to parse mock URL for route", "error", err.Error())
 		http.Error(w, fmt.Sprintf("failed to parse mock URL for route: %s",
 			err.Error()), http.StatusInternalServerError)
 	}
+	ms.logger.Info("parsed URL", "path", path)
 	switch route.Type {
 	case "http":
 		ms.logger.Info("detected an http mock attempt")

--- a/pkg/mock/route_test.go
+++ b/pkg/mock/route_test.go
@@ -76,6 +76,17 @@ func TestParseURL(t *testing.T) {
 			wantPath:         "/git/github.com/example-repo/.git",
 			wantTransformers: []Transformer{},
 		},
+		{
+			name: "git strip ports",
+			route: &Route{
+				Host: "gitlab.tfe:31080",
+				Path: "/test/test-project",
+				Type: "git",
+			},
+			url:              "http://gitlab.tfe:31080/test/test-project",
+			wantPath:         "/git/gitlab.tfe/test/test-project/.git",
+			wantTransformers: []Transformer{},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Even if the Route Host is on a custom port, the filepath must not be (this breaks logic for parsing Endpoint logic in the git client library)