### PR TITLE
Rename project to mock-proxy.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,11 +1,14 @@
-# Contributing to vcs-mock-proxy
+# Contributing to mock-proxy
 
-vcs-mock-proxy is an open source project and we appreciate contributions of various
+mock-proxy is an open source project and we appreciate contributions of various
 kinds, including bug reports and fixes, enhancement proposals, documentation
-updates, and user experience feedback. However, this is not an officially supported HashiCorp product. We _are_ grateful for all contributions, but this repository is primarily maintained by a small team at HashiCorp outside of their main job responsibilities and is developed on a volunteer basis.
+updates, and user experience feedback. However, this is not an officially
+supported HashiCorp product. We _are_ grateful for all contributions, but this
+repository is primarily maintained by a small team at HashiCorp outside of
+their main job responsibilities and is developed on a volunteer basis.
 
 To record a bug report, enhancement proposal, or give any other product
-feedback, please [open a GitHub issue](https://github.com/hashicorp/vcs-mock-proxy/issues/new).
+feedback, please [open a GitHub issue](https://github.com/hashicorp/mock-proxy/issues/new).
 
 **All communication on GitHub, the community forum, and other HashiCorp-provided
 communication channels is subject to
@@ -13,13 +16,17 @@ communication channels is subject to
 
 ## Local Development Environment
 
-vcs-mock-proxy has a simple proxying setup configured in docker-compose for use while developing changes locally. To start up this local development environment run:
+mock-proxy has a simple proxying setup configured in docker-compose for use
+while developing changes locally. To start up this local development
+environment run:
 
 ```
 ./hack/local-dev-up.sh
 ```
 
-This starts the Squid proxy, an ICAP server implemented by vcs-mock-proxy, and a client that is using that proxy. You can see a simple mock implemented by running:
+This starts the Squid proxy, an ICAP server implemented by mock-proxy, and a
+client that is using that proxy. You can see a simple mock implemented by
+running:
 
 ```
 curl https://example.com
@@ -27,7 +34,8 @@ curl https://example.com
 
 ## Running Tests
 
-vcs-mock-proxy has a test suite implemented for its Golang components. To run the tests, run:
+mock-proxy has a test suite implemented for its Golang components. To run the
+tests, run:
 
 ```
 go test ./...
@@ -41,19 +49,19 @@ go test -v -race ./...
 
 ## External Dependencies
 
-vcs-mock-proxy uses Go Modules for dependency management.
+mock-proxy uses Go Modules for dependency management.
 
-Our dependency licensing policy for vcs-mock-proxy excludes proprietary licenses
+Our dependency licensing policy for mock-proxy excludes proprietary licenses
 and "copyleft"-style licenses. We accept the common Mozilla Public License v2,
 MIT License, and BSD licenses. We will consider other open source licenses
 in similar spirit to those three, but if you plan to include such a dependency
 in a contribution we'd recommend opening a GitHub issue first to discuss what
 you intend to implement and what dependencies it will require so that the
-vcs-mock-proxy team can review the relevant licenses for whether they meet our
+mock-proxy team can review the relevant licenses for whether they meet our
 licensing needs.
 
-If you need to add a new dependency to vcs-mock-proxy or update the selected version
-for an existing one, use `go get` from the root of the vcs-mock-proxy repository
+If you need to add a new dependency to mock-proxy or update the selected version
+for an existing one, use `go get` from the root of the mock-proxy repository
 as follows:
 
 ```
@@ -76,7 +84,7 @@ than some other change types to become conflicted with other proposed changes
 during the code review process. For that reason, and to make dependency changes
 more visible in the change history, we prefer to record dependency changes as
 separate commits that include only the results of the above commands and the
-minimal set of changes to vcs-mock-proxy's own code for compatibility with the
+minimal set of changes to mock-proxy's own code for compatibility with the
 new version:
 
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Don't commit the binary
-cmd/vcs-mock-proxy/vcs-mock-proxy
+cmd/mock-proxy/mock-proxy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# VCS Mock Proxy
-_a.k.a. VCS Moxy_
+# mock-proxy
+_a.k.a. Moxie_
 
 It is written in Go and relies on the HTTP intercept capabilities of [ICAP](https://tools.ietf.org/html/rfc3507), as implemented in [go-icap/icap](https://github.com/go-icap/icap). In short, ICAP allows us to specify a set of criteria to match all requests against and then routes them accordingly. When a request hits the proxy, if it matches this criteria then a semi-hardcoded response is automatically short circuited in. If it does not match the criteria, the request proceeds as normal.
 
@@ -13,11 +13,11 @@ In general, this project attempts to stick to the layout prescribed in [golang-s
 
 `build`: CircleCI and Docker build scripts. Also includes relevant squid proxy [config](build/package/docker/configs/squid.conf) and [setup script](build/package/docker/scripts/squid-icap-init.sh).
 
-`cmd`: Contains main.go file for building vcs-mock-proxy.
+`cmd`: Contains main.go file for building mock-proxy.
 
-`deployments`: Configs for publishing builds of vcs-mock-proxy.
+`deployments`: Configs for publishing builds of mock-proxy.
 
-`hack`: Bash scripts for running vcs-mock-proxy locally, since a straight `docker-compose up` won't work.
+`hack`: Bash scripts for running mock-proxy locally, since a straight `docker-compose up` won't work.
 
 `mocks`: Faux endpoints for testing the proxy redirect within this project. The `atlas` project houses endpoints used by itself in [atlas/integration-tests-api](https://github.com/hashicorp/atlas/tree/master/integration-tests-api/mocks).
 
@@ -55,7 +55,7 @@ Do not create overlapping routes. This will cause an error, as the mock routing 
 
 ## Mocking Git Clones
 
-vcs-mock-proxy also supports mocking Git Clones made via HTTP. To do so, add a route to your routes.hcl file:
+mock-proxy also supports mocking Git Clones made via HTTP. To do so, add a route to your routes.hcl file:
 
 ```hcl
 route {
@@ -85,10 +85,10 @@ curl --head --header "X-Desired-Response-Code: 204" example.com
 
 ## SSL Certificates and Mocking HTTPS requests
 
-Using Squid's SSL Bump configuration, VCS Mock Proxy can also act as an `https_proxy` and successfully mock upstream requests to HTTPS endpoints.
+Using Squid's SSL Bump configuration, mock-proxy can also act as an `https_proxy` and successfully mock upstream requests to HTTPS endpoints.
 
 It does so in this local configuration using a self-signed certificate in `/certs`. This self-signed cert is automatically trusted for local dev, and shoud work out of the box.
 
-If configuring VCS Mock Proxy in another environment, you will need to volume mount a self-signed certificate to `/etc/squid/ssl_cert/ca.pem`, and trust that certificate on any system attempting to use VCS Mock Proxy as an `https_proxy`.
+If configuring mock-proxy in another environment, you will need to volume mount a self-signed certificate to `/etc/squid/ssl_cert/ca.pem`, and trust that certificate on any system attempting to use mock-proxy as an `https_proxy`.
 
-To generate these certificates, use the script: `/hack/gen-certs.sh`. This may also be useful example code if you need to incorporate self-signed certs into another system using VCS Mock Proxy.
+To generate these certificates, use the script: `/hack/gen-certs.sh`. This may also be useful example code if you need to incorporate self-signed certs into another system using mock-proxy.

--- a/build/package/docker/Dockerfile
+++ b/build/package/docker/Dockerfile
@@ -5,7 +5,7 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GO111MODULE=on
 
-WORKDIR /go/src/github.com/hashicorp/vcs-mock-proxy
+WORKDIR /go/src/github.com/hashicorp/mock-proxy
 
 # Improve build hit rate
 COPY go.mod go.mod
@@ -13,7 +13,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 COPY ./ .
-RUN go build -o vcs-mock-proxy ./cmd/vcs-mock-proxy
+RUN go build -o mock-proxy ./cmd/mock-proxy
 
 FROM alpine:3.9
 RUN apk add --no-cache ca-certificates squid dumb-init bash git
@@ -22,8 +22,8 @@ WORKDIR /
 # Initialize Squid SSL db.
 RUN /usr/lib/squid/security_file_certgen -c -s /var/lib/ssl_db -M 4MB
 
-COPY --from=builder /go/src/github.com/hashicorp/vcs-mock-proxy/vcs-mock-proxy .
-COPY --from=builder /go/src/github.com/hashicorp/vcs-mock-proxy/mocks ./mocks
+COPY --from=builder /go/src/github.com/hashicorp/mock-proxy/mock-proxy .
+COPY --from=builder /go/src/github.com/hashicorp/mock-proxy/mocks ./mocks
 
 COPY ./build/package/docker/configs/squid.conf /etc/squid/squid.conf
 COPY ./build/package/docker/configs/squid-ssl.conf /etc/squid/squid-ssl.conf

--- a/build/package/docker/scripts/squid-icap-init.sh
+++ b/build/package/docker/scripts/squid-icap-init.sh
@@ -11,8 +11,8 @@ trap '
   fi
 ' CHLD
 
-# Background the VCS proxy ICAP protocol.
-/vcs-mock-proxy & PIDS+=("$!")
+# Background the mock-proxy ICAP protocol server.
+/mock-proxy & PIDS+=("$!")
 
 # TODO: Is this necessary?
 sleep 1

--- a/cmd/mock-proxy/main.go
+++ b/cmd/mock-proxy/main.go
@@ -6,12 +6,12 @@ import (
 	"strconv"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/vcs-mock-proxy/pkg/mock"
+	"github.com/hashicorp/mock-proxy/pkg/mock"
 )
 
 func main() {
 	if err := inner(); err != nil {
-		hclog.Default().Error("vcs-mock-proxy error: %s\n", err)
+		hclog.Default().Error("mock-proxy error: %s\n", err)
 		os.Exit(1)
 	}
 }
@@ -33,7 +33,7 @@ func inner() error {
 	}
 
 	options = append(options, mock.WithLogger(hclog.New(&hclog.LoggerOptions{
-		Name:  "vcs-mock-proxy",
+		Name:  "mock-proxy",
 		Level: hclog.LevelFromString(logLevel),
 	})))
 

--- a/deployments/deploy.hcl
+++ b/deployments/deploy.hcl
@@ -1,3 +1,7 @@
+# The "vcs-mock-proxy" project name refers to HashiCorp's internal use of this
+# tool (mocking version control software providers). You may see scattered use
+# of this name throughout the project, but should ignore it in favor of just
+# mock-proxy.
 project   = "vcs-mock-proxy"
 deploy_id = env.BUILD_ID
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/vcs-mock-proxy
+module github.com/hashicorp/mock-proxy
 
 go 1.13
 

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -142,7 +142,7 @@ func (ms *MockServer) Serve() error {
 	http.HandleFunc("/", ms.mockHandler)
 	icap.HandleFunc("/icap", ms.interception)
 
-	// We also create a custom ServeMux vcs-mock-proxy API endpoints
+	// We also create a custom ServeMux mock-proxy API endpoints
 	apiMux := http.NewServeMux()
 	apiMux.HandleFunc("/substitution-variables", ms.substitutionVariableHandler)
 


### PR DESCRIPTION
The "vcs" moniker implies this is only useful for mocking Version Control Software providers, which isn't true. It limits the audience for the project, which is no good.

Remove it, and just call the project `mock-proxy` or `Moxie`.