### PR TITLE
Move to TDP ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/team-tf-developer-productivity


### PR DESCRIPTION
A step for the ticket "[Move mock-proxy to TDP ownership](https://app.asana.com/0/1200249492698539/1201795621119182/f)".
This is to define that Terraform Developer Productivity team will be responsible for code in a repository.
